### PR TITLE
Improve result printing and add optional FastPeopleSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # freedom-skiptracer
 
-This project provides a simple skip tracing utility that searches free public data
-sources for phone numbers associated with a property address. It uses
-Playwright with a headless Chromium browser to better mimic real browsers and
-avoid simple anti-bot protections.
+This project provides a simple skip tracing utility that searches free public data sources for phone numbers associated with a property address. It uses Playwright with a headless Chromium browser to better mimic real browsers and avoid simple anti-bot protections.
 
 ## Installation
 
@@ -11,22 +8,29 @@ Install the dependencies with pip:
 
 ```bash
 pip install -r requirements.txt
-Usage
+```
 
+## Usage
+
+```bash
 python skiptracer.py "709 W High St, Portland, IN"
+```
+
 Optional flags:
---debug
-Save the last HTML response to logs/debug_last.html
---visible
-Launch the browser in non-headless mode
---proxy URL
-Launch the browser using a proxy (e.g., http://user:pass@host:port)
-Use --debug to print verbose logs and save the last HTML response to logs/debug_last.html when a request fails or is blocked.
 
-Output Format
+- `--debug` – Save the last HTML response to `logs/debug_last.html`
+- `--visible` – Launch the browser in non-headless mode
+- `--proxy URL` – Launch the browser using a proxy (e.g., `http://user:pass@host:port`)
+- `--fast` – Include FastPeopleSearch (may trigger bot checks)
+- `--save` – Write results to `results.json`
 
-The script will attempt to look up matches on TruePeopleSearch.com and FastPeopleSearch.com and output a list of potential matches in the form:
+Use `--debug` to print verbose logs and save the last HTML response when a request fails or is blocked.
 
+## Output Format
+
+The script looks up matches on TruePeopleSearch and optionally FastPeopleSearch and outputs a list of potential matches in the form:
+
+```
 [
   {
     "name": "John D Smith",
@@ -35,16 +39,6 @@ The script will attempt to look up matches on TruePeopleSearch.com and FastPeopl
     "source": "TruePeopleSearch"
   }
 ]
+```
+
 Only publicly available information is queried and returned.
-
-
----
-
-### 🧠 After that:
-
-1. Save the file.
-2. In your terminal (still inside `freedom-skiptracer` folder), run:
-
-```bash
-git add README.md
-git commit -m "Resolve merge conflict in README"

--- a/skiptracer.py
+++ b/skiptracer.py
@@ -132,17 +132,31 @@ def search_fastpeoplesearch(context, address: str, debug: bool) -> List[Dict[str
     return results
 
 
-def skip_trace(address: str, visible: bool = False, proxy: str | None = None, debug: bool = False) -> List[Dict[str, object]]:
+def skip_trace(
+    address: str,
+    visible: bool = False,
+    proxy: str | None = None,
+    include_fastpeoplesearch: bool = False,
+    debug: bool = False,
+) -> List[Dict[str, object]]:
     ua = random.choice(USER_AGENTS)
     with sync_playwright() as p:
         launch_args = {"headless": not visible}
         if proxy:
             launch_args["proxy"] = {"server": proxy}
         browser = p.chromium.launch(**launch_args)
-        context = browser.new_context(user_agent=ua, viewport={"width": 1366, "height": 768})
+        context = browser.new_context(
+            user_agent=ua, viewport={"width": 1366, "height": 768}
+        )
         results = search_truepeoplesearch(context, address, debug)
-        if not results:
-            results = search_fastpeoplesearch(context, address, debug)
+
+        if include_fastpeoplesearch:
+            try:
+                fps_results = search_fastpeoplesearch(context, address, debug)
+                results.extend(fps_results)
+            except Exception as exc:  # pragma: no cover - network call
+                if debug:
+                    print(f"FastPeopleSearch failed: {exc}")
         browser.close()
     return results
 
@@ -153,9 +167,29 @@ def main() -> None:
     parser.add_argument("--debug", action="store_true", help="Save last HTML response")
     parser.add_argument("--visible", action="store_true", help="Run browser visibly")
     parser.add_argument("--proxy", help="Proxy server e.g. http://user:pass@host:port")
+    parser.add_argument(
+        "--fast",
+        action="store_true",
+        help="Include FastPeopleSearch (may trigger bot checks)",
+    )
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="Write results to results.json",
+    )
     args = parser.parse_args()
 
-    matches = skip_trace(args.address, visible=args.visible, proxy=args.proxy, debug=args.debug)
+    matches = skip_trace(
+        args.address,
+        visible=args.visible,
+        proxy=args.proxy,
+        include_fastpeoplesearch=args.fast,
+        debug=args.debug,
+    )
+
+    if args.save:
+        Path("results.json").write_text(json.dumps(matches, indent=2))
+
     if matches:
         print(json.dumps(matches, indent=2))
     else:


### PR DESCRIPTION
## Summary
- handle FastPeopleSearch failures without crashing
- make FastPeopleSearch optional with `--fast`
- add `--save` option to write results.json
- document new flags in README

## Testing
- `python -m py_compile skiptracer.py`