### PR TITLE
Improve result printing and add optional FastPeopleSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # freedom-skiptracer
 
-This project provides a simple skip tracing utility that searches free public data
-sources for phone numbers associated with a property address. It uses
-Playwright with a headless Chromium browser to better mimic real browsers and
-avoid simple anti-bot protections.
+This project provides a simple skip tracing utility that searches free public data sources for phone numbers associated with a property address. It uses Playwright with a headless Chromium browser to better mimic real browsers and avoid simple anti-bot protections. TruePeopleSearch is accessed by filling out the on-page form just like a user.
 
 ## Installation
 
@@ -11,22 +8,29 @@ Install the dependencies with pip:
 
 ```bash
 pip install -r requirements.txt
-Usage
+```
 
+## Usage
+
+```bash
 python skiptracer.py "709 W High St, Portland, IN"
+```
+
 Optional flags:
---debug
-Save the last HTML response to logs/debug_last.html
---visible
-Launch the browser in non-headless mode
---proxy URL
-Launch the browser using a proxy (e.g., http://user:pass@host:port)
-Use --debug to print verbose logs and save the last HTML response to logs/debug_last.html when a request fails or is blocked.
 
-Output Format
+- `--debug` – Save the last HTML response to `logs/debug_last.html`
+- `--visible` – Launch the browser in non-headless mode
+- `--proxy URL` – Launch the browser using a proxy (e.g., `http://user:pass@host:port`)
+- `--fast` – Include FastPeopleSearch (may trigger bot checks)
+- `--save` – Write results to `results.json`
 
-The script will attempt to look up matches on TruePeopleSearch.com and FastPeopleSearch.com and output a list of potential matches in the form:
+Use `--debug` to print verbose logs and save the last HTML response when a request fails or is blocked.
 
+## Output Format
+
+The script looks up matches on TruePeopleSearch and optionally FastPeopleSearch and outputs a list of potential matches in the form:
+
+```
 [
   {
     "name": "John D Smith",
@@ -35,16 +39,6 @@ The script will attempt to look up matches on TruePeopleSearch.com and FastPeopl
     "source": "TruePeopleSearch"
   }
 ]
+```
+
 Only publicly available information is queried and returned.
-
-
----
-
-### 🧠 After that:
-
-1. Save the file.
-2. In your terminal (still inside `freedom-skiptracer` folder), run:
-
-```bash
-git add README.md
-git commit -m "Resolve merge conflict in README"


### PR DESCRIPTION
## Summary
- handle FastPeopleSearch failures without crashing
- make FastPeopleSearch optional with `--fast`
- add `--save` option to write results.json
- interact with TruePeopleSearch form to bypass address query blocks

## Testing
- `python -m py_compile skiptracer.py`
