### PR TITLE
Handle robot check after submit

### DIFF
--- a/skiptracer.py
+++ b/skiptracer.py
@@ -50,6 +50,20 @@ def apply_stealth(page) -> None:
         """
     )
 
+def fetch_html(context, url: str, debug: bool) -> str:
+    """Navigate to a URL in a fresh page and return the HTML."""
+    page = context.new_page()
+    apply_stealth(page)
+    response = page.goto(url, wait_until="domcontentloaded", timeout=30000)
+    time.sleep(random.uniform(0.3, 0.7))
+    html = page.content()
+    if debug:
+        save_debug_html(html)
+    if response and response.status >= 400:
+        raise ValueError(f"HTTP {response.status}")
+    page.close()
+    return html
+
 def search_truepeoplesearch(context, address: str, debug: bool, inspect: bool) -> List[Dict[str, object]]:
     if debug:
         print("Trying TruePeopleSearch...")
@@ -67,7 +81,7 @@ def search_truepeoplesearch(context, address: str, debug: bool, inspect: bool) -
     try:
         address_input = page.locator("input[placeholder*='Enter name']").first
         address_input.wait_for(timeout=5000)
-        address_input.type(address, delay=75)
+        address_input.type(address, delay=random.randint(50, 100))
     except Exception:
         if debug:
             print("Failed to locate or type into address input field")
@@ -79,6 +93,7 @@ def search_truepeoplesearch(context, address: str, debug: bool, inspect: bool) -
 
     try:
         address_input.press("Enter")
+        time.sleep(3)
     except Exception:
         try:
             page.click("button[type='submit']")
@@ -89,14 +104,49 @@ def search_truepeoplesearch(context, address: str, debug: bool, inspect: bool) -
             return []
 
     page.wait_for_load_state("domcontentloaded")
+    try:
+        page.wait_for_selector("div.card", timeout=8000)
+    except Exception:
+        pass
+    page.mouse.wheel(0, random.randint(200, 800))
     html = page.content()
     if debug:
-        save_debug_html(html)
+        Path("logs").mkdir(exist_ok=True)
+        Path("logs/page_after_submit.html").write_text(html)
+
+    lower_html = html.lower()
+    bot_check = False
+    if (
+        "are you a human" in lower_html
+        or "robot check" in lower_html
+        or ("verify" in lower_html and "robot" in lower_html)
+    ):
+        bot_check = True
+    else:
+        try:
+            if page.locator("text=verify", has_text="robot").first.is_visible(timeout=1000):
+                bot_check = True
+        except Exception:
+            pass
+
+    if bot_check:
+        print("Bot check detected — waiting 10s and retrying...")
+        if debug:
+            Path("logs/page_after_submit.html").write_text(html)
+        page.pause()
+        time.sleep(10)
+        page.reload()
+        page.wait_for_load_state("domcontentloaded")
+        html = page.content()
+        if debug:
+            save_debug_html(html)
 
     soup = BeautifulSoup(html, "html.parser")
     cards = soup.select("div.card a[href*='/details']")
     if debug:
         print(f"Found {len(cards)} cards on TruePeopleSearch")
+    if len(cards) == 0:
+        print("No cards found — likely bot block or bad selector.")
     if inspect:
         for card in cards:
             print("TPS card:\n", card.get_text(" ", strip=True))
@@ -107,7 +157,12 @@ def search_truepeoplesearch(context, address: str, debug: bool, inspect: bool) -
         if not href:
             continue
         detail_url = href if href.startswith("http") else f"https://www.truepeoplesearch.com{href}"
-        detail_html = fetch_html(context, detail_url, debug)
+        try:
+            detail_html = fetch_html(context, detail_url, debug)
+        except Exception as e:
+            if debug:
+                print(f"Error loading detail page: {e}")
+            continue
         detail_soup = BeautifulSoup(detail_html, "html.parser")
         name_el = detail_soup.find(["h1", "h2", "strong"])
         name = name_el.get_text(strip=True) if name_el else ""
@@ -128,12 +183,77 @@ def search_truepeoplesearch(context, address: str, debug: bool, inspect: bool) -
     page.close()
     return results
 
+
+def search_fastpeoplesearch(context, address: str, debug: bool, inspect: bool) -> List[Dict[str, object]]:
+    """Searches FastPeopleSearch for the given address."""
+    if debug:
+        print("Trying FastPeopleSearch...")
+
+    slug = quote_plus(address.lower().replace(",", "").replace(" ", "-"))
+    url = f"https://www.fastpeoplesearch.com/address/{slug}"
+
+    page = context.new_page()
+    apply_stealth(page)
+    page.goto(url, wait_until="domcontentloaded", timeout=30000)
+    time.sleep(3)
+    try:
+        page.wait_for_selector("div.card", timeout=8000)
+    except Exception:
+        pass
+    page.mouse.wheel(0, random.randint(200, 800))
+    html = page.content()
+    if debug:
+        save_debug_html(html)
+
+    soup = BeautifulSoup(html, "html.parser")
+    cards = soup.select("div.card a[href*='/person']")
+    if debug:
+        print(f"Found {len(cards)} cards on FastPeopleSearch")
+    if len(cards) == 0:
+        print("No cards found — likely bot block or bad selector.")
+    if inspect:
+        for card in cards:
+            print("FPS card:\n", card.get_text(" ", strip=True))
+
+    results = []
+    for link in cards:
+        href = link.get("href")
+        if not href:
+            continue
+        detail_url = href if href.startswith("http") else f"https://www.fastpeoplesearch.com{href}"
+        try:
+            detail_html = fetch_html(context, detail_url, debug)
+        except Exception as e:
+            if debug:
+                print(f"Error loading detail page: {e}")
+            continue
+        detail_soup = BeautifulSoup(detail_html, "html.parser")
+        name_el = detail_soup.find(["h1", "h2", "strong"])
+        name = name_el.get_text(strip=True) if name_el else ""
+        loc_el = detail_soup.find(string=re.compile("Current Address", re.I))
+        if loc_el and loc_el.find_parent("div"):
+            location_div = loc_el.find_parent("div").find_next_sibling("div")
+            location = location_div.get_text(strip=True) if location_div else ""
+        else:
+            location = ""
+        phones = _parse_phones(detail_soup.get_text(" "))
+        if name or phones:
+            results.append({
+                "name": name,
+                "phones": phones,
+                "city_state": location,
+                "source": "FastPeopleSearch",
+            })
+    page.close()
+    return results
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Autonomous skip tracing tool")
     parser.add_argument("address", help="Property address")
     parser.add_argument("--debug", action="store_true", help="Save HTML and log status codes")
     parser.add_argument("--visible", action="store_true", help="Show browser during scrape")
     parser.add_argument("--inspect", action="store_true", help="Print raw HTML card text")
+    parser.add_argument("--fast", action="store_true", help="Include FastPeopleSearch")
     parser.add_argument("--save", action="store_true", help="Write results to results.json")
     args = parser.parse_args()
 
@@ -141,7 +261,21 @@ def main() -> None:
         browser = p.chromium.launch(headless=not args.visible)
         context = browser.new_context(user_agent=random.choice(USER_AGENTS), viewport={"width": 1366, "height": 768})
 
-        results = search_truepeoplesearch(context, args.address, args.debug, args.inspect)
+        results: List[Dict[str, object]] = []
+        try:
+            results.extend(search_truepeoplesearch(context, args.address, args.debug, args.inspect))
+        except Exception as e:
+            if args.debug:
+                print(f"TruePeopleSearch failed: {e}")
+
+        if args.fast:
+            try:
+                results.extend(
+                    search_fastpeoplesearch(context, args.address, args.debug, args.inspect)
+                )
+            except Exception as e:
+                if args.debug:
+                    print(f"FastPeopleSearch failed: {e}")
 
         context.close()
         browser.close()


### PR DESCRIPTION
## Summary
- add missing `fetch_html` helper
- log page after submitting search
- detect post-submit robot check and retry
- retry gracefully when detail pages fail
- scroll results and wait for selectors
- attempt FastPeopleSearch with `--fast`

## Testing
- `python -m py_compile skiptracer.py`
