### PR TITLE
Fix TruePeopleSearch invocation

### DIFF
--- a/skiptracer.py
+++ b/skiptracer.py
@@ -421,26 +421,17 @@ def main() -> None:
 
         results: List[Dict[str, object]] = []
         try:
-            results.extend(
-                search_truepeoplesearch(
+            results.extend(search_truepeoplesearch(
                     context,
                     args.address,
                     args.debug,
                     args.inspect,
                     args.visible,
                     args.manual,
-
-                )
-            )
+                ))
         except Exception as exc:
             if args.debug:
                 print(f"TruePeopleSearch failed: {exc}")
-        results: List[Dict[str, object]] = []
-        try:
-            results.extend(search_truepeoplesearch(context, args.address, args.debug, args.inspect))
-        except Exception as e:
-            if args.debug:
-                print(f"TruePeopleSearch failed: {e}")
 
         if args.fast:
             try:


### PR DESCRIPTION
## Summary
- keep single call to `search_truepeoplesearch` in `main`
- remove duplicate invocation and redundant assignment
- correct parentheses so `results.extend(search_truepeoplesearch(...))` is continuous

## Testing
- `python3 -m py_compile skiptracer.py` *(fails: IndentationError in existing code)*