### PR TITLE
Remove unused os import

### DIFF
--- a/skiptracer.py
+++ b/skiptracer.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import os
 import random
 import re
 import time


### PR DESCRIPTION
## Summary
- clean up imports in `skiptracer.py` by dropping `os`

## Testing
- `python -m py_compile skiptracer.py` *(fails: IndentationError in existing code)*