### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+logs/


### PR DESCRIPTION
## Summary
- add .gitignore to ignore cache, bytecode, and logs

## Testing
- `python -m py_compile skiptracer.py` *(fails: IndentationError)*