### PR TITLE
Fix threading import error

### DIFF
--- a/skiptracer.py
+++ b/skiptracer.py
@@ -4,6 +4,7 @@ import logging
 import random
 import re
 import time
+import threading
 from pathlib import Path
 from typing import List, Dict, Optional
 from urllib.parse import quote_plus, urlsplit


### PR DESCRIPTION
## Summary
- import `threading` at the top of **skiptracer.py** to avoid a `NameError`

## Testing
- `python -m py_compile skiptracer.py`
- `python skiptracer.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*