### PR TITLE
Fix default parallel usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Optional flags:
   uses a Decodo residential proxy configured in `skiptracer.py`.
 - `--fast` – Include FastPeopleSearch (may trigger bot checks)
 - `--save` – Write results to `results.json`
-- `--parallel N` – Run N browser contexts in parallel using separate proxies
+- `--parallel [N]` – Run N browser contexts in parallel using separate proxies. If N is omitted, 5 contexts are used by default.
 
 Use `--debug` to print verbose logs and save the last HTML response when a request fails or is blocked.
 

--- a/skiptracer.py
+++ b/skiptracer.py
@@ -1269,8 +1269,10 @@ def main() -> None:
     parser.add_argument(
         "--parallel",
         type=int,
-        default=0,
-        help="Number of parallel browser contexts to run",
+        nargs="?",
+        const=5,
+        default=5,
+        help="Number of parallel browser contexts to run (default: 5)",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- allow `--parallel` to be specified without a value
- document that parallel defaults to 5 contexts

## Testing
- `python3 -m py_compile skiptracer.py`
- `python3 skiptracer.py "1 test" --parallel --fast --manual --visible --debug` *(fails: ModuleNotFoundError: No module named 'numpy')*