### PR TITLE
Fix focus when entering location

### DIFF
--- a/skiptracer.py
+++ b/skiptracer.py
@@ -17,7 +17,6 @@ from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.common.keys import Keys
 from selenium.common.exceptions import TimeoutException, ElementClickInterceptedException
 
 # List of mobile proxies that must be used
@@ -292,7 +291,7 @@ def search_truepeoplesearch(address: str, proxy: str, debug: bool = False, headl
         except Exception:
             traceback.print_exc()
             try:
-                street_input.send_keys(Keys.TAB)
+                driver.execute_script("arguments[0].click()", location_input)
             except Exception:
                 traceback.print_exc()
 


### PR DESCRIPTION
## Summary
- remove unused Keys import
- ensure the bot focuses the city input field by clicking it and avoid using TAB

## Testing
- `python3 -m py_compile skiptracer.py`
- `python3 skiptracer.py --help` *(fails: ModuleNotFoundError: No module named 'undetected_chromedriver')*