### PR TITLE
Add search failure logging

### DIFF
--- a/skiptracer.py
+++ b/skiptracer.py
@@ -340,6 +340,7 @@ def search_truepeoplesearch(address: str, proxy: str, debug: bool = False, headl
         traceback.print_exc()
         if debug:
             capture_debug()
+        logger.error("Search failed")
         raise
     finally:
         driver.quit()


### PR DESCRIPTION
## Summary
- log when `search_truepeoplesearch` fails by emitting `logger.error("Search failed")`

## Testing
- `python -m py_compile skiptracer.py`
