### PR TITLE
Fix Decodo payload and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python skiptracer.py [--request-timeout SECONDS] [--visible] [--batch-size N]
 Running this command generates an `output.csv` file in the same directory. The
 script writes the scraped name, address, and phone number for each row to this
 file, overwriting any existing content.
-Use `--request-timeout` to change the HTTP timeout, which defaults to 60 seconds.
+Use `--request-timeout` to change the HTTP timeout, which defaults to 120 seconds.
 Pass `--visible` to print the full HTML returned by the scraper for each address.
 Set `--batch-size` to send multiple addresses in a single request using
 Decodo's batch API.
@@ -41,13 +41,15 @@ following JSON payload:
 {
   "url": "https://www.truepeoplesearch.com/results?name=&citystatezip=IN+47371",
   "headless": "html",
-  "geo": "United States",
-  "locale": "en-us",
+  "http_method": "GET",
+  "geo": "us",
+  "locale": "en-US",
   "device_type": "desktop_chrome",
-  "session_id": "Skip 1",
-  "headers": {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-  }
+  "session_id": "skip-session-1",
+  "browser_actions": [
+    {"type": "scroll_to_bottom", "wait_time_s": 2},
+    {"type": "click", "selector": {"type": "css", "value": ".load-more-button"}, "wait_time_s": 1}
+  ]
 }
 ```
 Requests use HTTP basic authentication with the credentials from your `.env` file.

--- a/skiptracer.py
+++ b/skiptracer.py
@@ -47,7 +47,7 @@ def _parse_phones(text: str):
 class Scraper:
     """Simple helper for fetching pages from Decodo's API."""
 
-    def __init__(self, timeout: int = 60) -> None:
+    def __init__(self, timeout: int = 120) -> None:
         self.timeout = timeout
 
     def fetch(self, url: str, *, visible: bool = False) -> str:
@@ -58,8 +58,8 @@ class Scraper:
             "url": url,
             "headless": "html",
             "http_method": "GET",
-            "geo": "United States",
-            "locale": "en-us",
+            "geo": "us",
+            "locale": "en-US",
             "device_type": "desktop_chrome",
             "session_id": "skip-session-1",
             "browser_actions": [


### PR DESCRIPTION
## Summary
- update Decodo API options in `Scraper.fetch`
- bump default timeout to 120 seconds
- document the new JSON payload and timeout

## Testing
- `python -m py_compile skiptracer.py`