### PR TITLE
Handle Decodo results array and render wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ The scraper sends a POST request to Decodo for each address using a payload simi
   "http_method": "GET",
   "geo": "US",
   "locale": "en-US",
-  "session_id": "skip-session-1"
+  "session_id": "tsp-session-1",
+  "wait_for": "networkidle",
+  "render_wait_time_ms": 6000
 }
 ```
 Requests use HTTP basic authentication with the credentials from your `.env` file. Each


### PR DESCRIPTION
## Summary
- add `wait_for` and `render_wait_time_ms` options to Decodo payload
- support `results` array in Decodo 613 response
- mark empty HTML as `Render Timeout`
- document new payload fields in README

## Testing
- `python -m py_compile skiptracer.py`