### PR TITLE
Allow built‑in Decodo token

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
+# Optional: define your Decodo API token here
 DECODO_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Install the dependencies with pip:
 pip install -r requirements.txt
 ```
 
-Create a `.env` file containing your Decodo API token:
+Create a `.env` file containing your Decodo API token (or edit `skiptracer.py`
+and place your token in `_BUILTIN_DECODO_API_TOKEN`):
 
 ```bash
 DECODO_API_TOKEN=<your token>

--- a/skiptracer.py
+++ b/skiptracer.py
@@ -11,7 +11,11 @@ from dotenv import load_dotenv
 
 # ── ENV ─────────────────────────────────────────────────────────────────────────
 load_dotenv()
-DECODO_API_TOKEN = os.getenv("DECODO_API_TOKEN")
+# Optional: directly place your Decodo API token in this variable
+_BUILTIN_DECODO_API_TOKEN = ""
+
+# Read from environment first, then fallback to the builtin token
+DECODO_API_TOKEN = os.getenv("DECODO_API_TOKEN") or _BUILTIN_DECODO_API_TOKEN
 if not DECODO_API_TOKEN:
     raise RuntimeError("DECODO_API_TOKEN not set")
 
@@ -28,9 +32,9 @@ def _parse_phones(text: str) -> List[str]:
 
 def fetch_tps_via_decodo(address: str, timeout: int) -> str:
     from urllib.parse import quote_plus
-    import os, json, requests, logging
+    import json, requests, logging
 
-    token = os.getenv("DECODO_API_TOKEN")
+    token = DECODO_API_TOKEN
     if not token:
         raise RuntimeError("DECODO_API_TOKEN not set")
 


### PR DESCRIPTION
## Summary
- support a built-in `_BUILTIN_DECODO_API_TOKEN` in `skiptracer.py`
- document the new option in the README
- add comment in `.env` describing where to set the token

## Testing
- `python -m py_compile skiptracer.py`
- `python skiptracer.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*