### PR TITLE
Add dotenv support and token CLI override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment configuration for skiptracer
+# Copy to .env and set your Decodo API token
+DECODO_API_TOKEN=your-token-here

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__/
 *.pyc
 logs/
 .env
+
+# secrets
+.env


### PR DESCRIPTION
## Summary
- load environment from `.env` with python-dotenv
- add `get_decodo_token` helper and `--api-token` CLI option
- mask API token in debug output
- keep `.env` out of version control and provide `.env.example`

## Testing
- `python -m py_compile skiptracer.py`
- `python skiptracer.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*
